### PR TITLE
Update ANTs version to 2.6

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -24,7 +24,7 @@ dependencies:
   - graphviz=9.0
   - pandoc=3.1
   # Workflow dependencies: ANTs
-  - ants=2.5
+  - ants=2.6
   # Other dependencies
   - pip
   - pip:

--- a/src/fmripost_rapidtide/workflows/base.py
+++ b/src/fmripost_rapidtide/workflows/base.py
@@ -456,8 +456,11 @@ def init_fit_single_run_wf(*, bold_file):
             reference_image=functional_cache['boldref'],
             transforms=[functional_cache['boldref2anat']],
             invert_transform_flags=[True],
+            num_threads=config.nipype.omp_nthreads,
         ),
         name='dseg_to_boldref',
+        mem_gb=mem_gb['filesize'],
+        n_procs=config.nipype.omp_nthreads,
     )
 
     if ('bold_native' not in functional_cache) and ('bold_raw' in functional_cache):

--- a/src/fmripost_rapidtide/workflows/base.py
+++ b/src/fmripost_rapidtide/workflows/base.py
@@ -450,7 +450,7 @@ def init_fit_single_run_wf(*, bold_file):
     dseg_to_boldref = pe.Node(
         ApplyTransforms(
             dimension=3,
-            input_image_type=2,
+            input_image_type=0,
             interpolation='GenericLabel',
             input_image=functional_cache['anat_dseg'],
             reference_image=functional_cache['boldref'],

--- a/src/fmripost_rapidtide/workflows/confounds.py
+++ b/src/fmripost_rapidtide/workflows/confounds.py
@@ -122,7 +122,7 @@ def init_denoising_confounds_wf(
     warp_mask_to_nlin6 = pe.Node(
         ApplyTransforms(
             dimension=3,
-            input_image_type=2,
+            input_image_type=0,
             interpolation='GenericLabel',
         ),
         name='warp_mask_to_nlin6',


### PR DESCRIPTION
Closes none, but is related to https://github.com/conda-forge/ants-feedstock/issues/19.

## Changes proposed in this pull request

- Change ANTs version from 2.5 to 2.6.
- Use the correct input-image-type for 3D volumes.