### PR TITLE
Bump rapidtide requirement to 3.0.4

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,8 +36,6 @@ Command-Line Arguments
 .. argparse::
    :ref: fmripost_rapidtide.cli.parser._build_parser
    :prog: fmripost_rapidtide
-   :nodefault:
-   :nodefaultconst:
 
 .. _prev_derivs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "nitransforms",
   "niworkflows",
   "pybids >= 0.15.6",
-  "rapidtide == 3.0.2",
+  "rapidtide == 3.0.4",
   "sdcflows",
   "smriprep",
   "typer",

--- a/src/fmripost_rapidtide/cli/parser.py
+++ b/src/fmripost_rapidtide/cli/parser.py
@@ -41,8 +41,8 @@ def _build_parser(**kwargs):
     from rapidtide.workflows.rapidtide_parser import (
         DEFAULT_CORRWEIGHTING,
         DEFAULT_DETREND_ORDER,
-        DEFAULT_GLOBAL_PCACOMPONENTS,
         DEFAULT_GLOBALSIGNAL_METHOD,
+        DEFAULT_INITREGRESSOR_PCACOMPONENTS,
         DEFAULT_LAGMAX,
         DEFAULT_LAGMAX_THRESH,
         DEFAULT_LAGMIN,
@@ -356,7 +356,7 @@ def _build_parser(**kwargs):
             'If VALUE is negative, the number of components will be to retain will be selected '
             'automatically using the MLE method.'
         ),
-        default=DEFAULT_GLOBAL_PCACOMPONENTS,
+        default=DEFAULT_INITREGRESSOR_PCACOMPONENTS,
     )
     preproc.add_argument(
         '--numtozero',

--- a/src/fmripost_rapidtide/cli/parser.py
+++ b/src/fmripost_rapidtide/cli/parser.py
@@ -41,7 +41,7 @@ def _build_parser(**kwargs):
     from rapidtide.workflows.rapidtide_parser import (
         DEFAULT_CORRWEIGHTING,
         DEFAULT_DETREND_ORDER,
-        DEFAULT_GLOBALSIGNAL_METHOD,
+        DEFAULT_INITREGRESSOR_METHOD,
         DEFAULT_INITREGRESSOR_PCACOMPONENTS,
         DEFAULT_LAGMAX,
         DEFAULT_LAGMAX_THRESH,
@@ -340,7 +340,7 @@ def _build_parser(**kwargs):
             'MLE PCA of the voxels in the global signal mask, '
             'or initializing using random noise.'
         ),
-        default=DEFAULT_GLOBALSIGNAL_METHOD,
+        default=DEFAULT_INITREGRESSOR_METHOD,
     )
     preproc.add_argument(
         '--globalpcacomponents',

--- a/src/fmripost_rapidtide/cli/parser.py
+++ b/src/fmripost_rapidtide/cli/parser.py
@@ -194,10 +194,8 @@ def _build_parser(**kwargs):
     )
 
     # Rapidtide options
-    g_rapidtide = parser.add_argument_group('Options for running rapidtide')
-
     # Preprocessing options
-    preproc = g_rapidtide.add_argument_group('Preprocessing options')
+    preproc = parser.add_argument_group('Preprocessing options')
     preproc.add_argument(
         '--autosync',
         dest='autosync',
@@ -263,7 +261,7 @@ def _build_parser(**kwargs):
     )
 
     # Add permutation options
-    sigcalc_opts = g_rapidtide.add_argument_group('Significance calculation options')
+    sigcalc_opts = parser.add_argument_group('Significance calculation options')
     sigcalc_opts.add_argument(
         '--numnull',
         dest='numnull',
@@ -389,7 +387,7 @@ def _build_parser(**kwargs):
     )
 
     # Correlation options
-    corr = g_rapidtide.add_argument_group('Correlation options')
+    corr = parser.add_argument_group('Correlation options')
     corr.add_argument(
         '--corrweighting',
         dest='corrweighting',
@@ -429,7 +427,7 @@ def _build_parser(**kwargs):
     )
 
     # Correlation fitting options
-    corr_fit = g_rapidtide.add_argument_group('Correlation fitting options')
+    corr_fit = parser.add_argument_group('Correlation fitting options')
     fixdelay = corr_fit.add_mutually_exclusive_group()
     fixdelay.add_argument(
         '--fixdelay',
@@ -468,7 +466,7 @@ def _build_parser(**kwargs):
     )
 
     # Regressor refinement options
-    reg_ref = g_rapidtide.add_argument_group('Regressor refinement options')
+    reg_ref = parser.add_argument_group('Regressor refinement options')
     reg_ref.add_argument(
         '--lagminthresh',
         dest='lagminthresh',
@@ -552,7 +550,7 @@ def _build_parser(**kwargs):
     )
 
     # GLM noise removal options
-    glm = g_rapidtide.add_argument_group('GLM noise removal options')
+    glm = parser.add_argument_group('GLM noise removal options')
     glm.add_argument(
         '--glmsourcefile',
         dest='glmsourcefile',
@@ -576,7 +574,7 @@ def _build_parser(**kwargs):
     )
 
     # Output options
-    output = g_rapidtide.add_argument_group('Output options')
+    output = parser.add_argument_group('Output options')
     output.add_argument(
         '--outputlevel',
         dest='outputlevel',
@@ -597,7 +595,7 @@ def _build_parser(**kwargs):
     )
 
     # Experimental options (not fully tested, may not work)
-    experimental = g_rapidtide.add_argument_group(
+    experimental = parser.add_argument_group(
         'Experimental options (not fully tested, or not tested at all, may not work).  Beware!'
     )
     experimental.add_argument(


### PR DESCRIPTION
Closes none, but should address the current failure listed below.

```
Cmdline:
    rapidtide --noprogressbar --spcalculation --noglm --ampthresh -1.000000 --brainmask /data/derivatives/fmriprep/sub-01/ses-04/func/sub-01_ses-04_task-rest_desc-brain_mask.nii.gz --confoundderiv --confoundpowers 1 --corrweighting phat --datatstep 0.720000 --detrendorder 3 --filterband lfo --glmderivs 0 --globalmeaninclude /work/fmripost_rapidtide_0_0_wf/sub_01_wf/single_run_ses_04_task_rest_wf/rapidtide_ses_04_task_rest_wf/split_tissues/gm.nii.gz --globalpcacomponents 0.800000 --globalsignalmethod sum --graymattermask /work/fmripost_rapidtide_0_0_wf/sub_01_wf/single_run_ses_04_task_rest_wf/rapidtide_ses_04_task_rest_wf/split_tissues/gm.nii.gz --lagmaxthresh 3.000000 --lagminthresh 0.250000 --maxpasses 15 --motionfile /data/derivatives/fmriprep/sub-01/ses-04/func/sub-01_ses-04_task-rest_desc-confounds_timeseries.tsv --nprocs 8 --numnull 10000 --numskip 2 --numtozero 0 --offsetinclude /work/fmripost_rapidtide_0_0_wf/sub_01_wf/single_run_ses_04_task_rest_wf/rapidtide_ses_04_task_rest_wf/split_tissues/gm.nii.gz --outputlevel normal --pcacomponents 0.800000 --refineinclude /work/fmripost_rapidtide_0_0_wf/sub_01_wf/single_run_ses_04_task_rest_wf/rapidtide_ses_04_task_rest_wf/split_tissues/gm.nii.gz --searchrange -30 30 --sigmalimit 1000.000000 --sigmathresh 100.000000 --simcalcrange -1 -1 --spatialfilt -1.000000 --timerange -1 -1 --whitemattermask /work/fmripost_rapidtide_0_0_wf/sub_01_wf/single_run_ses_04_task_rest_wf/rapidtide_ses_04_task_rest_wf/split_tissues/wm.nii.gz /data/derivatives/fmriprep/sub-01/ses-04/func/sub-01_ses-04_task-rest_desc-preproc_bold.nii.gz /work/fmripost_rapidtide_0_0_wf/sub_01_wf/single_run_ses_04_task_rest_wf/rapidtide_ses_04_task_rest_wf/rapidtide/rapidtide
Stdout:

Stderr:
    Traceback (most recent call last):
      File "/opt/conda/envs/fmripost_rapidtide/bin/rapidtide", line 8, in <module>
        sys.exit(entrypoint())
                 ^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/site-packages/rapidtide/scripts/rapidtide.py", line 24, in entrypoint
        rapidtide_workflow.rapidtide_main(rapidtide_parser.process_args(inputargs=None))
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/site-packages/rapidtide/workflows/rapidtide_parser.py", line 1727, in process_args
        inargs, argstowrite = pf.setargs(_get_parser, inputargs=inputargs)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/site-packages/rapidtide/workflows/parser_funcs.py", line 882, in setargs
        args = thegetparserfunc().parse_args()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/argparse.py", line 1874, in parse_args
        args, argv = self.parse_known_args(args, namespace)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/argparse.py", line 1907, in parse_known_args
        namespace, args = self._parse_known_args(args, namespace)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/argparse.py", line 2110, in _parse_known_args
        positionals_end_index = consume_positionals(start_index)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/argparse.py", line 2087, in consume_positionals
        take_action(action, args)
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/argparse.py", line 1967, in take_action
        argument_values = self._get_values(action, argument_strings)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/argparse.py", line 2506, in _get_values
        value = self._get_value(action, arg_string)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/argparse.py", line 2539, in _get_value
        result = type_func(arg_string)
                 ^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/site-packages/rapidtide/workflows/rapidtide_parser.py", line 122, in <lambda>
        type=lambda x: pf.is_valid_file(parser, x),
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/site-packages/rapidtide/workflows/parser_funcs.py", line 65, in is_valid_file
        thefilename, colspec = tide_io.parsefilespec(arg)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/conda/envs/fmripost_rapidtide/lib/python3.11/site-packages/rapidtide/io.py", line 1941, in parsefilespec
        if filespec[1] == ":" and platform.system() == "Windows":
           ~~~~~~~~^^^
    IndexError: string index out of range
```